### PR TITLE
Set `lang: en` for English Abstract

### DIFF
--- a/template/frontmatter.typ
+++ b/template/frontmatter.typ
@@ -6,28 +6,31 @@
 	ch-keywords:[],
 	en-keywords:[]
 ) = {
-
-	set page(
-		header:  header-fun(numberformat:  "i", thiscontent: [摘要]),
-		footer: []
-	)
-	heading(level: 1, outlined: false)[摘要]
-	ch-abstract
-	parbreak()
-	h(-2em) 
-	text(font: ("Times New Roman","SimHei"))[关键词：#ch-keywords ]
+	{
+		set page(
+			header: header-fun(numberformat: "i", thiscontent: [摘要]),
+			footer: [],
+		)
+		heading(level: 1, outlined: false)[摘要]
+		ch-abstract
+		parbreak()
+		h(-2em)
+		text(font: ("Times New Roman", "SimHei"))[关键词：#ch-keywords ]
+	}
 	pagebreak()
 
-
-	set page(
-		header:  header-fun(numberformat:  "i", thiscontent: [Abstract]),
-		footer: []
-	)
-	heading(level: 1, outlined: false)[Abstract]
-	en-abstract
-	parbreak()
-	h(-2em) 
-	strong[Key words: #en-keywords]
+	{
+		set page(
+			header: header-fun(numberformat: "i", thiscontent: [Abstract]),
+			footer: [],
+		)
+		set text(lang: "en")
+		heading(level: 1, outlined: false)[Abstract]
+		en-abstract
+		parbreak()
+		h(-2em)
+		strong[Key words: #en-keywords]
+	}
 	pagebreak()
 }
 


### PR DESCRIPTION
中英文模式下的排版略有区别，这里启用为英文摘要启用英文排版来更加符合排版习惯